### PR TITLE
Fix "unable to parse iw" Error

### DIFF
--- a/wifi_heat_mapper/misc.py
+++ b/wifi_heat_mapper/misc.py
@@ -181,9 +181,9 @@ def process_iw(target_interface):
         results["channel"] = int(tmp[0])
         results["channel_frequency"] = int(tmp[1].replace("(", ""))
 
-        try: 
+        try:
             results["ssid"] = re.findall(r"(?<=ssid )(.*)", iw_info)[0]
-        except IndexError: 
+        except IndexError:
             print("iw {0} info command cannot find required SSID. Trying iw {0} link".format(target_interface))
 
             iw_link = get_application_output(

--- a/wifi_heat_mapper/misc.py
+++ b/wifi_heat_mapper/misc.py
@@ -180,7 +180,22 @@ def process_iw(target_interface):
         tmp = re.findall(r"(?<=channel )(.*?)(?=\,)", iw_info)[0].split(" ")
         results["channel"] = int(tmp[0])
         results["channel_frequency"] = int(tmp[1].replace("(", ""))
-        results["ssid"] = re.findall(r"(?<=ssid )(.*)", iw_info)[0]
+
+        try: 
+            results["ssid"] = re.findall(r"(?<=ssid )(.*)", iw_info)[0]
+        except IndexError: 
+            print("iw {0} info command cannot find required SSID. Trying iw {0} link".format(target_interface))
+
+            iw_link = get_application_output(
+                ["iw {0} link".format(target_interface)],
+                shell=True, timeout=10).replace("\t", " ")
+
+            if iw_link == "invalid":
+                print("iw {0} link command failed.".format(target_interface))
+                exit(1)
+
+            results["ssid"] = re.findall(r"(?<=SSID: )(.*)", iw_link)[0]
+
         iw_info = get_application_output(["iw {0} station dump".format(target_interface)],
                                          shell=True, timeout=10).replace("\t", " ")
         results["ssid_mac"] = re.findall(r"(?<=Station )(.*)(?= \()", iw_info)[0]


### PR DESCRIPTION
This PR aims to solve the problem described in #6 

- closes #6

### Problem 

Following is example of executing `whm bootstrap` which currently results in `wifi_heat_mapper.misc.ParseError`. (Ignore the `launch.py` - the only thing it does is calling `wifi_heat_mapper.main:driver()`)

```
python3 launcher.py bootstrap
Detecting benchmarking capabilities.
Supported Modes: iperf3
Please enter the target wireless interface to run benchmark on (example: wlan0): wlan0
Traceback (most recent call last):
  File "/home/.../launcher.py", line 4, in <module>
    driver()
  File "/home/.../wifi_heat_mapper/main.py", line 81, in driver
    start_config(args.config_file)
  File "/home/.../wifi_heat_mapper/debugger.py", line 12, in new_func
    return func(*args, **kwargs)
  File "/home/.../wifi_heat_mapper/config.py", line 228, in start_config
    ssid = process_iw(target_interface)["ssid"]
  File "/home/.../wifi_heat_mapper/misc.py", line 197, in process_iw
    raise ParseError("Unable to parse iw.") from None
wifi_heat_mapper.misc.ParseError: Unable to parse iw.
```

As described in the logs, there is a problem with parsing `ssid: `, from `iw <wif> info` command. The exact line where the problem lies is `misc.py:183`:

``` python
        results["channel_frequency"] = int(tmp[1].replace("(", ""))
>       results["ssid"] = re.findall(r"(?<=ssid )(.*)", iw_info)[0]
        iw_info = get_application_output(["iw {0} station dump".format(target_interface)],
```
This expression raises `IndexError` which is catched at the end of the function.

### Cause 

The problem is probably related to update of the generated output by `iw` tool. Current version installed on my OS is `5.9` (`iw --version`). 

Example output: 

``` 
$ iw wlan0 info
Interface wlan0
        ifindex 3
        wdev 0x1
        addr 50:eb:71:be:37:fa
        type managed
        wiphy 0
        channel 6 (2437 MHz), width: 20 MHz, center1: 2437 MHz
        txpower 22.00 dBm
        multicast TXQ:
                qsz-byt qsz-pkt flows   drops   marks   overlmt hashcol tx-bytes        tx-packets
                0       0       0       0       0       0       0       0               0
```

As we can see there is no `ssid` field. 
Currently info about SSID can be obtained using `iw <wif> link` cmd.
Example: 

``` bash
$ iw wlan0 link
Connected to aa:aa:aa:aa:aa:aa (on wlan0)
        SSID: WIFI-HEATMAPS-TEST
        freq: 2437
        RX: 3378 bytes (21 packets)
        TX: 2870 bytes (26 packets)
        signal: -15 dBm
        rx bitrate: 52.0 MBit/s MCS 5
        tx bitrate: 65.0 MBit/s MCS 7

        bss flags:      short-slot-time
        dtim period:    2
        beacon int:     100
```

### Solution 

The simplest solution is to use `iw <wif> link` output to obtain the SSID. In this PR this is implemented by first checking `iw <wif> info` output and by catching `IndexError`. If exception is raised we can use the same function `get_application_output()` to get output from `iw <wif> link`. Information about trying to run `iw <wif> link` is logged to the user. This approach has following benefits:

- `iw <wif> info` is still the default approach
- `iw <wif> link` is not launched until needed (`info` failed)
- user gets information about the process of trying different commands

 This is backward-compatible solution so I believe it won't "spoil" implementation in older version of `iw`.

```
$ python3 launcher.py bootstrap 
Detecting benchmarking capabilities.
Supported Modes: iperf3
Please enter the target wireless interface to run benchmark on (example: wlan0): wlan0
iw wlan0 info command cannot find required SSID. Trying iw wlan0 link
You are connected to WIFI-HEATMAPS-TEST. Is this the interface you want to benchmark on? (y/N) y
How many times do you want to repeat benchmarking? 3
```