### PR TITLE
Update display settings

### DIFF
--- a/wifi_heat_mapper/graph.py
+++ b/wifi_heat_mapper/graph.py
@@ -4,6 +4,7 @@ from wifi_heat_mapper.debugger import log_arguments
 from PIL import Image
 import matplotlib.pyplot as plt
 import numpy as np
+import math
 from matplotlib.pyplot import imread
 from scipy.interpolate import Rbf
 from tqdm import tqdm
@@ -134,13 +135,23 @@ class GraphPlot:
         ax.imshow(imread(self.floor_map)[::-1], interpolation='bicubic', zorder=1, alpha=1,
                   origin="lower")
 
-        fig.colorbar(bench_plot)
+        title_size = max(10, math.sqrt(fdimx * fdimy) // 70)
+        label_size = max(7, title_size - 5)
+
+        cb = fig.colorbar(bench_plot)
+        cb.ax.tick_params(labelsize=label_size)
         desc = ConfigurationOptions.configuration[self.key]["description"]
         if self.suffix is not None:
             desc = desc.format(self.suffix)
-        plt.title("{0}".format(desc))
+
+        plt.title("{0}".format(desc), fontsize=title_size)
         plt.axis('off')
-        plt.legend(bbox_to_anchor=(0.55, -0.05), ncol=2)
+        plt.legend(
+            loc='upper center', 
+            bbox_to_anchor=(0.5, -0.05), 
+            ncol=2, 
+            prop={"size": label_size}
+        )
         file_name = "{0}.{1}".format(self.key, file_type)
         plt.savefig(file_name, format=file_type, dpi=dpi)
 

--- a/wifi_heat_mapper/graph.py
+++ b/wifi_heat_mapper/graph.py
@@ -124,18 +124,20 @@ class GraphPlot:
         bench_plot = ax.contourf(xi, yi, zi, cmap="RdYlBu_r", vmin=self.vmin, vmax=self.vmax,
                                  alpha=0.5, zorder=150, antialiased=True, levels=levels)
 
+        fdim_coef = math.sqrt(fdimx * fdimy)
+        marker_size = max(4, fdim_coef // 210) 
         ax.plot(self.processed_results["x"], self.processed_results["y"], zorder=200, marker='o',
-                markeredgecolor='black', markeredgewidth=0.5, linestyle='None', markersize=5,
+                markeredgecolor='black', markeredgewidth=0.5, linestyle='None', markersize=marker_size,
                 label="Benchmark Point")
 
         ax.plot(self.processed_results["sx"], self.processed_results["sy"], zorder=250, marker='o',
                 markeredgecolor='black', markerfacecolor="orange", markeredgewidth=0.5,
-                linestyle='None', markersize=5, label="Base Station")
+                linestyle='None', markersize=marker_size, label="Base Station")
 
         ax.imshow(imread(self.floor_map)[::-1], interpolation='bicubic', zorder=1, alpha=1,
                   origin="lower")
 
-        title_size = max(10, math.sqrt(fdimx * fdimy) // 70)
+        title_size = max(10, fdim_coef // 70)
         label_size = max(7, title_size - 5)
 
         cb = fig.colorbar(bench_plot)

--- a/wifi_heat_mapper/graph.py
+++ b/wifi_heat_mapper/graph.py
@@ -107,11 +107,9 @@ class GraphPlot:
         if self.conversion:
             self.apply_conversion()
 
-        minimum = 0
-        maximum = max(self.floor_map_dimensions)
-
-        xi = np.linspace(minimum, maximum, 100)
-        yi = np.linspace(minimum, maximum, 100)
+        fdimx, fdimy = self.floor_map_dimensions
+        xi = np.linspace(0, fdimx, 100)
+        yi = np.linspace(0, fdimy, 100)
 
         xi, yi = np.meshgrid(xi, yi)
         di = Rbf(self.processed_results["x"], self.processed_results["y"],
@@ -120,7 +118,7 @@ class GraphPlot:
         zi[zi < self.vmin] = self.vmin
         zi[zi > self.vmax] = self.vmax
 
-        fig, ax = plt.subplots(1, 1)
+        fig, ax = plt.subplots(1, 1, figsize=(fdimx / 100, fdimy / 100))
 
         bench_plot = ax.contourf(xi, yi, zi, cmap="RdYlBu_r", vmin=self.vmin, vmax=self.vmax,
                                  alpha=0.5, zorder=150, antialiased=True, levels=levels)

--- a/wifi_heat_mapper/graph.py
+++ b/wifi_heat_mapper/graph.py
@@ -125,7 +125,7 @@ class GraphPlot:
                                  alpha=0.5, zorder=150, antialiased=True, levels=levels)
 
         fdim_coef = math.sqrt(fdimx * fdimy)
-        marker_size = max(4, fdim_coef // 210) 
+        marker_size = max(4, fdim_coef // 210)
         ax.plot(self.processed_results["x"], self.processed_results["y"], zorder=200, marker='o',
                 markeredgecolor='black', markeredgewidth=0.5, linestyle='None', markersize=marker_size,
                 label="Benchmark Point")
@@ -149,9 +149,9 @@ class GraphPlot:
         plt.title("{0}".format(desc), fontsize=title_size)
         plt.axis('off')
         plt.legend(
-            loc='upper center', 
-            bbox_to_anchor=(0.5, -0.05), 
-            ncol=2, 
+            loc='upper center',
+            bbox_to_anchor=(0.5, -0.05),
+            ncol=2,
             prop={"size": label_size}
         )
         file_name = "{0}.{1}".format(self.key, file_type)

--- a/wifi_heat_mapper/gui.py
+++ b/wifi_heat_mapper/gui.py
@@ -396,10 +396,9 @@ def processed_results(benchmark_points):
     return results
 
 
-def get_img_data(f, maxsize=(1200, 850), first=False):
+def get_img_data(f, first=False):
     """Generate image data using PIL"""
     img = Image.open(f)
-    img.thumbnail(maxsize)
     if first:
         bio = io.BytesIO()
         img.save(bio, format="PNG")


### PR DESCRIPTION
This PR aims to help with working on bigger floor images and make the plotting more "flexible" for different formats

- probably closes #7 

## Problem 

Currently some of the parameters for plotting are hardcoded and overfitted to the floor plan inside `examples/` directory. This results in inproper handing of bigger image formats with `whm benchmark`

Given below is a example of floor plan image with resolution: `(2560, 831)`. This is perfectly fine example as even with simple PyGUI vertical images can be easily moved around the screen. 

![bad_pygui](https://github.com/Nischay-Pro/wifi-heat-mapper/assets/45858813/65fa237d-3dc0-48cb-88e3-b7bf1e69204b)

As we can see GUI "cuts" image to thumbnail with fixed size. 

Other problem is hardcoded plotting parameters for `whm plot`. 

![flat_sq](https://github.com/Nischay-Pro/wifi-heat-mapper/assets/45858813/17a0bf8f-7a58-4929-b2d2-97dea7e8e22a)

There are several problems to solve: 

- Image is downscaled to fixed ratio - not much can be seen on the result plot 
- Font sizes are fixed to specific resolution 
- Legend has offset based on given image - with different ratio it will appear in different places
- Benchmark points have fixed size

## Proposed Solution 

- Remove `thumbnail` cutting of given images and setting hardcoded `maxsize` to `1200 x 850` 
- Propose "heuristic" to scale font size and mark_sizes based on image dimensions 
  - This solution is not perfect (numbers are mostly magic, obtained by trial-and-error) - created to "work decent" in most cases   
- Move legend to "center" below the image 
  - This will help with implementation of #4 in the future  

## Obtained Results

Following section shows obtained results after applying changes described above

### `whm benchmark` results

Image below show that after removing `maxsize` and removing `thumbnail` we can work with full size images:

![fixed_pygui](https://github.com/Nischay-Pro/wifi-heat-mapper/assets/45858813/da593ebf-f2c7-4736-bc9a-21cce0aaa20e)

### `whm plot` results 

Following is a combination of obtained results with comparison to "baseline" (current) result

a) examples/floor_plan_white.png  `(651, 792)`

Result before changes: 

![example_sq](https://github.com/Nischay-Pro/wifi-heat-mapper/assets/45858813/f44c356b-6e1b-4c06-95c3-4b65648972f2)

Result after changes: 

![example_sq](https://github.com/Nischay-Pro/wifi-heat-mapper/assets/45858813/1ef9f6ed-ce54-41f8-b8d0-b235443171b6)


b) flat_example.png `(2560, 831)`

Result before changes: 

![flat_sq](https://github.com/Nischay-Pro/wifi-heat-mapper/assets/45858813/17a0bf8f-7a58-4929-b2d2-97dea7e8e22a)

Result after changes: 

![flat_sq](https://github.com/Nischay-Pro/wifi-heat-mapper/assets/45858813/c0ad6ffa-96b4-4e74-9b0e-8010d577e35f)

c) large_example.png `(2490, 2420)`

Result before changes: 

![large_sq](https://github.com/Nischay-Pro/wifi-heat-mapper/assets/45858813/dbb26b43-5e3d-4d39-8b77-3b8f84e6fe75)

Result after changes: 

![large_sq](https://github.com/Nischay-Pro/wifi-heat-mapper/assets/45858813/fd90d5fa-fbe7-411d-8532-fed369beb2f4)


## Future work 

A few ideas which would make working on bigger resolutions easier with `whm bechmark`:

- implement **zooming** / **moving around** the floor plain - with "window" having constant size / adjustable size and being able to move freely around the image 
   - this is probably harded / time consuming solution as needs changes with how GUI works
- implement "scaling" with cmd params 
  - one can launch `whm benchmark` with `scale_x=...` and `scale_y=...` or just `scale=...` params 
  - this launches image but shows it with applied scaling 
  - every "clicked" point generates scaled (`image_x = click_x` ) point on generated view, but saves real `x` as `click_x * scale_x` 
 
The second approach is probably not that hard to implement, is easy to work with, and allows working without changing how GUI works. 
There is no need to work on full-resolution images during the benchmark phase (as pixel-wise-accuracy is not needed) but it would be nice to see generated plots on full resolution of the floor plan.
