### PR TITLE
Add dirty support for macos; retry iperf3 on error; alert with sounds

### DIFF
--- a/wifi_heat_mapper/main.py
+++ b/wifi_heat_mapper/main.py
@@ -95,3 +95,7 @@ def driver():
 def print_version():
     """Prints the version of the package."""
     print(__version__)
+
+
+if __name__ == "__main__":
+    driver()


### PR DESCRIPTION
I've been looking for something like this package for ages! Very nice work.

Unfortunately, I run MacOS, so I created a quick-and-dirty version for Mac. It is rather a proof of concept rather than a full pull request, but I thought I might still share it for some ideas.  Not sure, whether I find the time to clean it up any time soon.

I did not find `iw` for Mac, so I used a combination of `ifconfig` and `airport` commands to get the necessary information.

Some features may be interesting for any OS, though:

* Occasionally, `iperf3` exited with an error. So a couple of retries would be nice, before crashing the program when the results cannot be added. (In lack of a "sum..." key in the resulting dict).
* A notification sound, alerting the user when a benchmark is completed or was aborted is very helpful, especially for multiple iterations. For Mac, I used text to speech feature `os.system("say 'Benchmark completed'")`

A thing I did not implement, but would also be nice:
* Optionally add the measurement results as number next to the respective points on the map.