### PR TITLE
Don't require the non-free PySimpleGUI 5.x library

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_requirements = [
     "Pillow>=8.2.0",
     "scipy>=1.6.0",
     "numpy>=1.20.0",
-    "PySimpleGUI>=4.34.0",
+    "PySimpleGUI-4-foss>=4.60.4.1",
 ]
 
 setup(


### PR DESCRIPTION
PySimpleGUI 5.x was moved to a non-free license, and 4.x packages were yanked. This prevents loading the non-free versions.

Articles:
https://news.ycombinator.com/item?id=39369354
https://www.reddit.com/r/freesoftware/comments/1beqi2j/about_a_month_ago_the_very_popular_pysimplegui/
https://discuss.python.org/t/pysimplegui-now-requires-a-paid-license-opinions/48790?page=2
